### PR TITLE
Context menu changes.

### DIFF
--- a/Controls/ObjectExplorer/ContextCommand.cs
+++ b/Controls/ObjectExplorer/ContextCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,6 +11,8 @@ namespace Thingie.WPF.Controls.ObjectExplorer
     public abstract class ContextCommand : ICommand
     {
         public abstract string Text { get; }
+
+        public virtual ObservableCollection<ContextCommand> SubmenuCommands { get; } = new ObservableCollection<ContextCommand>();
 
         public abstract Uri ImageUri { get; }
 

--- a/Controls/ObjectExplorer/ObjectExplorerUC.xaml
+++ b/Controls/ObjectExplorer/ObjectExplorerUC.xaml
@@ -53,9 +53,12 @@
                         <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
                         <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
                         <EventSetter Event="PreviewMouseDown" Handler="node_PreviewMouseLeftButtonDown"/>
+                        <EventSetter Event="KeyDown" Handler="node_PreviewKeyDown" />
                         <Setter Property="ContextMenu">
                             <Setter.Value>
                                 <ContextMenu ItemsSource="{Binding ContextCommands}" Visibility="{Binding ContextCommands.Count, Converter={conv:MapConverter 0:Collapsed;_default:Visible}}">
+                                    <EventSetter Event="GotFocus" Handler="contextMenu_GotFocus" />
+                                    <EventSetter Event="LostFocus" Handler="contextMenu_LostFocus" />
                                     <ContextMenu.Resources>
                                         <Image x:Key="miIcon"
                                                x:Shared="false"
@@ -63,6 +66,7 @@
                                     </ContextMenu.Resources>
                                     <ContextMenu.ItemContainerStyle>
                                         <Style TargetType="MenuItem">
+                                            <Setter Property="ItemsSource" Value="{Binding SubmenuCommands}" />
                                             <Setter Property="Padding" Value="2"/>
                                             <Setter Property="Command" Value="{Binding}" />
                                             <Setter Property="CommandParameter" Value="{Binding DataContext, RelativeSource={RelativeSource AncestorType=TreeViewItem}}" />


### PR DESCRIPTION
Add subcommands to ContextCommand and ItemsSource property in ObjectExplorer XAML to enable nesting in context menu. 
Add KeyDown event and event handler to handle pressing the enter key on an item in the explorer. Add fix for focus loss with WPF and Excel.