### PR TITLE
Bugfix/toggle grayout behavior

### DIFF
--- a/Behaviors/GrayoutImageBehavior.cs
+++ b/Behaviors/GrayoutImageBehavior.cs
@@ -148,7 +148,10 @@ namespace Thingie.WPF.Behaviors
                 else
                 {
                     var bitmapImage = default(BitmapImage);
-                    imageHashCodeBindingPairs[image.GetHashCode()] = image.GetBindingExpression(Image.SourceProperty).ParentBinding;
+                    if (image.GetBindingExpression(Image.SourceProperty) != null)
+                    {
+                        imageHashCodeBindingPairs[image.GetHashCode()] = image.GetBindingExpression(Image.SourceProperty).ParentBinding;
+                    }
 
                     if (image.Source is BitmapImage)
                         bitmapImage = (BitmapImage)image.Source;

--- a/Behaviors/GrayoutImageBehavior.cs
+++ b/Behaviors/GrayoutImageBehavior.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -16,10 +13,6 @@ namespace Thingie.WPF.Behaviors
         public static readonly DependencyProperty GrayOutOnDisabledProperty = DependencyProperty.RegisterAttached("GrayOutOnDisabled", typeof(bool), typeof(GrayoutImageBehavior), new PropertyMetadata(default(bool), OnGrayOutOnDisabledChanged));
         public static void SetGrayOutOnDisabled(Image element, bool value) { element.SetValue(GrayOutOnDisabledProperty, value); }
         public static bool GetGrayOutOnDisabled(Image element) { return (bool)element.GetValue(GrayOutOnDisabledProperty); }
-
-        public static readonly DependencyProperty GrayOutBindingImageOnDisabledProperty = DependencyProperty.RegisterAttached("GrayOutBindingImageOnDisabled", typeof(bool), typeof(GrayoutImageBehavior), new PropertyMetadata(default(bool), OnGrayOutBindingImageOnDisabledChanged));
-        public static void SetGrayOutBindingImageOnDisabled(Image element, bool value) { element.SetValue(GrayOutBindingImageOnDisabledProperty, value); }
-        public static bool GetGrayOutBindingImageOnDisabled(Image element) { return (bool)element.GetValue(GrayOutBindingImageOnDisabledProperty); }
 
         private static Dictionary<int, Binding> imageHashCodeBindingPairs = new Dictionary<int, Binding>();
 
@@ -40,25 +33,6 @@ namespace Thingie.WPF.Behaviors
             ToggleGrayOut(image); // initial call
         }
 
-        private static void OnGrayOutBindingImageOnDisabledChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args)
-        {
-            Image image = (Image)obj;
-
-            
-
-            image.IsEnabledChanged -= OnBindingImageIsEnabledChanged;
-            image.SourceUpdated -= BindingImage_SourceUpdated;
-            image.Loaded -= BindingImage_Loaded;
-
-            if ((bool)args.NewValue)
-            {
-                image.IsEnabledChanged += OnBindingImageIsEnabledChanged;
-                image.SourceUpdated += BindingImage_SourceUpdated;
-                image.Loaded += BindingImage_Loaded;
-            }
-            ToggleBindingImageGrayOut(image); // initial call
-        }
-
         private static void Image_Loaded(object sender, RoutedEventArgs e)
         {
             var image = (Image)sender;
@@ -77,63 +51,11 @@ namespace Thingie.WPF.Behaviors
             ToggleGrayOut(image);
         }
 
-        private static void BindingImage_Loaded(object sender, RoutedEventArgs e)
-        {
-            var image = (Image)sender;
-            ToggleBindingImageGrayOut(image);
-        }
-
-        private static void BindingImage_SourceUpdated(object sender, DataTransferEventArgs e)
-        {
-            var image = (Image)sender;
-            ToggleBindingImageGrayOut(image);
-        }
-
-        private static void OnBindingImageIsEnabledChanged(object sender, DependencyPropertyChangedEventArgs args)
-        {
-            var image = (Image)sender;
-            ToggleBindingImageGrayOut(image);
-        }
-
         private static void ToggleGrayOut(Image image)
         {
-            try
-            {
-                if (image.IsEnabled)
-                {
-                    var grayImage = image.Source as FormatConvertedBitmap;
-                    if (grayImage != null)
-                    {
-                        image.Source = grayImage.Source; // Set the Source property to the original value.
-                        image.OpacityMask = null; // Reset the Opacity Mask
-                        image.Opacity = 1.0;
-                    }
-                }
-                else
-                {
-                    var bitmapImage = default(BitmapImage);
+            if (image.Source == null)
+                return;
 
-                    if (image.Source is BitmapImage)
-                        bitmapImage = (BitmapImage)image.Source;
-                    else if (image.Source is BitmapSource && image.Source is FormatConvertedBitmap == false) // assume uri source
-                        bitmapImage = new BitmapImage(new Uri(image.Source.ToString()));
-
-                    if (bitmapImage != null)
-                    {
-                        image.Source = new FormatConvertedBitmap(bitmapImage, PixelFormats.Gray32Float, null, 0); // Get the source bitmap
-                        image.OpacityMask = new ImageBrush(bitmapImage); // Create Opacity Mask for grayscale image as FormatConvertedBitmap does not keep transparency info
-                        image.Opacity = 0.3; // optional: lower opacity
-                    }
-                }
-            }
-            catch (Exception)
-            {
-
-            }
-        }
-
-        private static void ToggleBindingImageGrayOut(Image image)
-        {
             try
             {
                 if (image.IsEnabled)
@@ -142,6 +64,7 @@ namespace Thingie.WPF.Behaviors
                     {
                         image.SetBinding(Image.SourceProperty, imageHashCodeBindingPairs[image.GetHashCode()]);
                     }
+
                     image.OpacityMask = null; // Reset the Opacity Mask
                     image.Opacity = 1.0;
                 }

--- a/Behaviors/GrayoutImageBehavior.cs
+++ b/Behaviors/GrayoutImageBehavior.cs
@@ -56,13 +56,16 @@ namespace Thingie.WPF.Behaviors
             if (image.Source == null)
                 return;
 
+            var imageHash = image.GetHashCode();
+
             try
             {
                 if (image.IsEnabled)
                 {
-                    if (image.GetBindingExpression(Image.SourceProperty) == null && imageHashCodeBindingPairs.ContainsKey(image.GetHashCode()))
+                    if (image.GetBindingExpression(Image.SourceProperty) == null && imageHashCodeBindingPairs.ContainsKey(imageHash))
                     {
-                        image.SetBinding(Image.SourceProperty, imageHashCodeBindingPairs[image.GetHashCode()]);
+                        image.SetBinding(Image.SourceProperty, imageHashCodeBindingPairs[imageHash]);
+                        imageHashCodeBindingPairs.Remove(imageHash);
                     }
 
                     image.OpacityMask = null; // Reset the Opacity Mask
@@ -73,7 +76,7 @@ namespace Thingie.WPF.Behaviors
                     var bitmapImage = default(BitmapImage);
                     if (image.GetBindingExpression(Image.SourceProperty) != null)
                     {
-                        imageHashCodeBindingPairs[image.GetHashCode()] = image.GetBindingExpression(Image.SourceProperty).ParentBinding;
+                        imageHashCodeBindingPairs[imageHash] = image.GetBindingExpression(Image.SourceProperty).ParentBinding;
                     }
 
                     if (image.Source is BitmapImage)


### PR DESCRIPTION
Added separate grayout behavior for toggle buttons (images) with bindings. It preserves the binding (if it exists) and reapplies it when the image is enabled. 

Explanation why the current implementation would not work:

> Let's imagine we have an image control with a source binding. If we apply the current grayout to the image, the source (and the binding, of course) gets overriden while setting the source to the current image with the grayout behavior (`image.Source = new FormatConvertedBitmap(bitmapImage, PixelFormats.Gray32Float, null, 0);`). 
Now, the binding no longer exists and there is no way to change the image via INotifyPropertyChanged. Why does this work on regular buttons? Well, regular buttons only have one image (one image source). So even if we have a source binding to some property, when applying the grayout behavior the source binding _**is**_ going to be overriden by setting the source, but the source that we set is that singular image source of the button. Basically the Source property changes from `Binding {ImageUri}` to `ImageUri` - which never changes. If there is something unclear about this explanation, let me know!