### PR TITLE
Feature/explicit node expand disable

### DIFF
--- a/Controls/ObjectExplorer/NodeVM.cs
+++ b/Controls/ObjectExplorer/NodeVM.cs
@@ -50,7 +50,7 @@ namespace Thingie.WPF.Controls.ObjectExplorer
 
         public virtual bool IsExpanded { get => isExpanded; set { isExpanded = value; OnPropertyChanged(nameof(IsExpanded)); } }
         public virtual bool IsSelected { get => isSelected; set { isSelected = value; OnPropertyChanged(nameof(IsSelected)); } }
-        public virtual bool CanExpand => true;
+        public virtual bool CanExpandOnDoubleClick => true;
         #endregion
 
         public NodeVM(string name)

--- a/Controls/ObjectExplorer/NodeVM.cs
+++ b/Controls/ObjectExplorer/NodeVM.cs
@@ -50,6 +50,7 @@ namespace Thingie.WPF.Controls.ObjectExplorer
 
         public virtual bool IsExpanded { get => isExpanded; set { isExpanded = value; OnPropertyChanged(nameof(IsExpanded)); } }
         public virtual bool IsSelected { get => isSelected; set { isSelected = value; OnPropertyChanged(nameof(IsSelected)); } }
+        public virtual bool CanExpand => true;
         #endregion
 
         public NodeVM(string name)

--- a/Controls/ObjectExplorer/ObjectExplorerUC.xaml
+++ b/Controls/ObjectExplorer/ObjectExplorerUC.xaml
@@ -57,8 +57,6 @@
                         <EventSetter Event="ContextMenuClosing" Handler="contextMenu_Closing" />
                         <EventSetter Event="PreviewMouseDown" Handler="node_PreviewMouseLeftButtonDown"/>
                         <EventSetter Event="KeyDown" Handler="node_PreviewKeyDown" />
-                        <EventSetter Event="PreviewMouseDoubleClick" Handler="node_PreviewMouseDoubleClick" />
-                        <EventSetter Event="MouseDoubleClick" Handler="TreeViewItem_MouseDoubleClick" />
                         <Setter Property="ContextMenu">
                             <Setter.Value>
                                 <ContextMenu ItemsSource="{Binding ContextCommands}" Visibility="{Binding ContextCommands.Count, Converter={conv:MapConverter 0:Collapsed;_default:Visible}}">

--- a/Controls/ObjectExplorer/ObjectExplorerUC.xaml
+++ b/Controls/ObjectExplorer/ObjectExplorerUC.xaml
@@ -57,6 +57,8 @@
                         <EventSetter Event="ContextMenuClosing" Handler="contextMenu_Closing" />
                         <EventSetter Event="PreviewMouseDown" Handler="node_PreviewMouseLeftButtonDown"/>
                         <EventSetter Event="KeyDown" Handler="node_PreviewKeyDown" />
+                        <EventSetter Event="PreviewMouseDoubleClick" Handler="node_PreviewMouseDoubleClick" />
+                        <EventSetter Event="MouseDoubleClick" Handler="TreeViewItem_MouseDoubleClick" />
                         <Setter Property="ContextMenu">
                             <Setter.Value>
                                 <ContextMenu ItemsSource="{Binding ContextCommands}" Visibility="{Binding ContextCommands.Count, Converter={conv:MapConverter 0:Collapsed;_default:Visible}}">

--- a/Controls/ObjectExplorer/ObjectExplorerUC.xaml.cs
+++ b/Controls/ObjectExplorer/ObjectExplorerUC.xaml.cs
@@ -370,5 +370,31 @@ namespace Thingie.WPF.Controls.ObjectExplorer
                 }
             }));
         }
+
+        private void node_PreviewMouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            //if ((sender as FrameworkElement).DataContext is NodeVM n)
+            //{
+            //    if (!n.CanExpand)
+            //    {
+            //        e.Handled = true;
+            //        if (n.CanActivate())
+            //            n.Activate();
+            //    }
+            //}
+        }
+
+        private void TreeViewItem_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if ((sender as FrameworkElement).DataContext is NodeVM n)
+            {
+                if (!n.CanExpand)
+                {
+                    e.Handled = true;
+                    if (n.CanActivate())
+                        n.Activate();
+                }
+            }
+        }
     }
 }

--- a/Controls/ObjectExplorer/ObjectExplorerUC.xaml.cs
+++ b/Controls/ObjectExplorer/ObjectExplorerUC.xaml.cs
@@ -155,7 +155,7 @@ namespace Thingie.WPF.Controls.ObjectExplorer
                 if (e.ClickCount == 2 && n.CanActivate())
                 {
                     n.Activate();
-                    if (!n.CanExpand)
+                    if (!n.CanExpandOnDoubleClick)
                         e.Handled = true;
                 }
             }

--- a/Controls/ObjectExplorer/ObjectExplorerUC.xaml.cs
+++ b/Controls/ObjectExplorer/ObjectExplorerUC.xaml.cs
@@ -153,7 +153,11 @@ namespace Thingie.WPF.Controls.ObjectExplorer
                     n.Select();
 
                 if (e.ClickCount == 2 && n.CanActivate())
+                {
                     n.Activate();
+                    if (!n.CanExpand)
+                        e.Handled = true;
+                }
             }
         }
 
@@ -369,32 +373,6 @@ namespace Thingie.WPF.Controls.ObjectExplorer
                     Trace.WriteLine("Cleared frame");
                 }
             }));
-        }
-
-        private void node_PreviewMouseDoubleClick(object sender, MouseButtonEventArgs e)
-        {
-            //if ((sender as FrameworkElement).DataContext is NodeVM n)
-            //{
-            //    if (!n.CanExpand)
-            //    {
-            //        e.Handled = true;
-            //        if (n.CanActivate())
-            //            n.Activate();
-            //    }
-            //}
-        }
-
-        private void TreeViewItem_MouseDoubleClick(object sender, MouseButtonEventArgs e)
-        {
-            if ((sender as FrameworkElement).DataContext is NodeVM n)
-            {
-                if (!n.CanExpand)
-                {
-                    e.Handled = true;
-                    if (n.CanActivate())
-                        n.Activate();
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Disabled node expansion in object explorer for nodes that shouldn't expand.