### PR TITLE
Add handler for TreeViewItem Selected event.

### DIFF
--- a/Controls/ObjectExplorer/ObjectExplorerUC.xaml
+++ b/Controls/ObjectExplorer/ObjectExplorerUC.xaml
@@ -56,6 +56,7 @@
                         <EventSetter Event="ContextMenuOpening" Handler="contextMenu_Opening" />
                         <EventSetter Event="ContextMenuClosing" Handler="contextMenu_Closing" />
                         <EventSetter Event="PreviewMouseDown" Handler="node_PreviewMouseLeftButtonDown"/>
+                        <EventSetter Event="Selected" Handler="TreeViewItem_Selected" />
                         <EventSetter Event="KeyDown" Handler="node_PreviewKeyDown" />
                         <Setter Property="ContextMenu">
                             <Setter.Value>

--- a/Controls/ObjectExplorer/ObjectExplorerUC.xaml
+++ b/Controls/ObjectExplorer/ObjectExplorerUC.xaml
@@ -56,7 +56,6 @@
                         <EventSetter Event="ContextMenuOpening" Handler="contextMenu_Opening" />
                         <EventSetter Event="ContextMenuClosing" Handler="contextMenu_Closing" />
                         <EventSetter Event="PreviewMouseDown" Handler="node_PreviewMouseLeftButtonDown"/>
-                        <EventSetter Event="Selected" Handler="TreeViewItem_Selected" />
                         <EventSetter Event="KeyDown" Handler="node_PreviewKeyDown" />
                         <Setter Property="ContextMenu">
                             <Setter.Value>

--- a/Controls/ObjectExplorer/ObjectExplorerUC.xaml.cs
+++ b/Controls/ObjectExplorer/ObjectExplorerUC.xaml.cs
@@ -144,10 +144,17 @@ namespace Thingie.WPF.Controls.ObjectExplorer
 
         private void node_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
+            NodeVM originalEventSourceVm = (e.OriginalSource as FrameworkElement).DataContext as NodeVM;
             NodeVM n = (sender as FrameworkElement).DataContext as NodeVM;
 
-            if (n != null && n.IsSelected)
+            if (n != null && originalEventSourceVm != null && n.Equals(originalEventSourceVm))
             {
+                if (Keyboard.Modifiers == ModifierKeys.Control && n.CanSelect())
+                {
+                    n.Select();
+                    e.Handled = true;
+                }
+
                 if (e.ClickCount == 2 && n.CanActivate())
                 {
                     n.Activate();
@@ -368,16 +375,6 @@ namespace Thingie.WPF.Controls.ObjectExplorer
                     Trace.WriteLine("Cleared frame");
                 }
             }));
-        }
-
-        private void TreeViewItem_Selected(object sender, RoutedEventArgs e)
-        {
-            var n = (sender as FrameworkElement).DataContext as NodeVM;
-            if (Keyboard.Modifiers == ModifierKeys.Control && n.CanSelect())
-            {
-                n.Select();
-                e.Handled = true;
-            }
         }
     }
 }

--- a/Controls/ObjectExplorer/ObjectExplorerUC.xaml.cs
+++ b/Controls/ObjectExplorer/ObjectExplorerUC.xaml.cs
@@ -144,16 +144,10 @@ namespace Thingie.WPF.Controls.ObjectExplorer
 
         private void node_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            // todo: this bubbles, check if source == e.originalsource and cancel if not
-
             NodeVM n = (sender as FrameworkElement).DataContext as NodeVM;
-            // adding `&& n.IsSelected` to detect if it is in fact the item being clicked, rather than a child item
-            // for some reason, the source and sender originally point to the parent before the child
+
             if (n != null && n.IsSelected)
             {
-                if (Keyboard.Modifiers == ModifierKeys.Control && n.CanSelect())
-                    n.Select();
-
                 if (e.ClickCount == 2 && n.CanActivate())
                 {
                     n.Activate();
@@ -374,6 +368,16 @@ namespace Thingie.WPF.Controls.ObjectExplorer
                     Trace.WriteLine("Cleared frame");
                 }
             }));
+        }
+
+        private void TreeViewItem_Selected(object sender, RoutedEventArgs e)
+        {
+            var n = (sender as FrameworkElement).DataContext as NodeVM;
+            if (Keyboard.Modifiers == ModifierKeys.Control && n.CanSelect())
+            {
+                n.Select();
+                e.Handled = true;
+            }
         }
     }
 }


### PR DESCRIPTION
The PreviewMouseDown event is a Routed event with its routing strategy being _**Tunneling**_, which means that the event starts from the topmost parent and tunnels down to the control that triggered the event. This means that the handler will be executed for every control in the topmost-parent to triggering control hierarchy.  

A workaround we mentioned when talking about this issue would be to check the OriginalSource of the event, but unfortunately I couldn't make that work because the OriginalSource is a TextBlock and the sender is a TreeViewItem. The only way to do this would be to compare the contents of the OriginalSource and the sender, but IMO this is unreliable/bad (can't make the code markup behave nicely):

`private void node_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
        {
            var origSourceText = (e.OriginalSource as TextBlock).Text;
            var senderText = (sender as TreeViewItem).Header.Name;
            NodeVM n = (sender as FrameworkElement).DataContext as NodeVM;

            if (n != null && senderText == origSourceText)
            {
                if (Keyboard.Modifiers == ModifierKeys.Control && n.CanSelect())
                {
                    n.Select();
                }
                if (e.ClickCount == 2 && n.CanActivate())
                {
                    n.Activate();
                    e.Handled = true;
                }
            }
        }`